### PR TITLE
16116: Update XML SCHEMA Definitions (XSD) from EA FAA UI Intake Over…

### DIFF
--- a/financial_assistance.xsd
+++ b/financial_assistance.xsd
@@ -3,9 +3,7 @@
 	<xs:include schemaLocation="common.xsd"/>
 	<xs:include schemaLocation="links.xsd"/>
 	<xs:include schemaLocation="individual.xsd"/>
-
 	<xs:element name="financial_assistance_application" type="FinancialAssistanceApplicationType"/>
-
 	<xs:complexType name="FinancialAssistanceApplicationType">
 		<xs:sequence>
 			<xs:element name="id" type="IdentifierType">
@@ -13,6 +11,9 @@
 					<xs:documentation>HBX-assigned identifier for this application.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="fin_app_id" type="xs:anyURI" minOccurs="0"/>
+			<xs:element name="haven_app_id" type="xs:anyURI" minOccurs="0"/>
+			<xs:element name="e_case_id" type="xs:anyURI" minOccurs="0"/>
 			<xs:element name="applicant_type" type="FinancialAssistanceApplicationApplicantNameType"/>
 			<xs:element name="request_type" type="FinancialAssistanceApplicationRequestNameType"/>
 			<xs:element name="motivation_type" type="FinancialAssistanceApplicationMotivationNameType"/>
@@ -44,18 +45,19 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="has_accepted_medicaid_terms" type="xs:boolean"/>
-			<xs:element name="has_accepted_attestation_terms" type="xs:boolean"/>
+			<xs:element name="has_accepted_medicaid_insurance_collection_terms" type="xs:boolean"/>
+			<xs:element name="has_accepted_parent_living_out_of_home_terms" type="xs:boolean"/>
+			<xs:element name="has_accepted_report_change_terms" type="xs:boolean"/>
 			<xs:element name="has_accepted_submission_terms" type="xs:boolean"/>
+			<xs:element name="has_accepted_attestation_terms" type="xs:boolean"/>
 			<xs:element name="assistance_tax_households" type="AssistanceTaxHouseholdsListType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="AssistanceTaxHouseholdsListType">
 		<xs:sequence>
-			<xs:element name="assistance_tax_household" type="AssistanceTaxHouseholdType" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element name="assistance_tax_household" type="AssistanceTaxHouseholdType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="AssistanceTaxHouseholdType">
 		<xs:sequence>
 			<xs:element name="id" type="IdentifierType">
@@ -68,13 +70,11 @@
 			<xs:element name="eligibility_determinations" type="AssistanceEligibilityDeterminationListType" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="AssistanceEligibilityDeterminationListType">
 		<xs:sequence>
-			<xs:element name="eligibility_determination" type="AssistanceEligibilityDeterminationType" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element name="eligibility_determination" type="AssistanceEligibilityDeterminationType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="AssistanceEligibilityDeterminationType">
 		<xs:sequence>
 			<xs:element name="id" type="IdentifierType"/>
@@ -115,13 +115,11 @@
 			<xs:group ref="OptionalResourceTimestampGroup"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="AssistanceEligibilityDeterminationApplicantListType">
 		<xs:sequence>
-			<xs:element name="eligibility_determination_applicant" type="AssistanceEligibilityDeterminationApplicantType" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element name="eligibility_determination_applicant" type="AssistanceEligibilityDeterminationApplicantType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="AssistanceEligibilityDeterminationApplicantType">
 		<xs:complexContent>
 			<xs:restriction base="IndividualType">
@@ -142,25 +140,22 @@
 					<xs:element name="is_insurance_assistance_eligible" type="xs:boolean"/>
 					<xs:element name="is_medicaid_chip_eligible" type="xs:boolean"/>
 					<xs:element name="person_health" type="IndividualHealthType" minOccurs="0"/>
-                  			<xs:element name="total_incomes_by_year" type="AssistedIndividualTotalIncomesByYearType"/>
+					<xs:element name="total_incomes_by_year" type="AssistedIndividualTotalIncomesByYearType"/>
 				</xs:sequence>
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="AssistanceTaxHouseholdMemberListType">
 		<xs:sequence>
 			<xs:element name="assistance_tax_household_member" type="FinancialAssistanceApplicantType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="AssistedTaxHouseholdIncomesByYearType">
 		<xs:annotation>
-	            <xs:documentation>Sum of all qualified household income sources, including incomes of person who pays taxes, spouse and dependents, less qualified deductions, by calendar year. Also includes information about verification of the income.</xs:documentation>
+			<xs:documentation>Sum of all qualified household income sources, including incomes of person who pays taxes, spouse and dependents, less qualified deductions, by calendar year. Also includes information about verification of the income.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-		<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
+			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 </xs:schema>

--- a/individual.xsd
+++ b/individual.xsd
@@ -4,7 +4,7 @@
 	<xs:include schemaLocation="common.xsd"/>
 	<xs:include schemaLocation="organization.xsd"/>
 	<xs:include schemaLocation="plan.xsd"/>
-
+	<xs:include schemaLocation="verification_services.xsd"/>
 	<xs:complexType name="AffectedMemberType">
 		<xs:sequence>
 			<xs:element name="member_before_changes" type="PersonType"/>
@@ -17,7 +17,6 @@
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
-
 	<xs:element name="applicant_links">
 		<xs:annotation>
 			<xs:documentation>Set of Individual references</xs:documentation>
@@ -606,7 +605,6 @@
 			<xs:element name="broker_role" type="BrokerRoleType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="FinancialAssistanceIncomeEntryType">
 		<xs:complexContent>
 			<xs:restriction base="FinancialAssistanceIncomeType">
@@ -630,7 +628,6 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="FinancialAssistanceApplicantIndivdualType">
 		<xs:complexContent>
 			<xs:restriction base="EligibilityDeterminationApplicantType">
@@ -655,7 +652,6 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="FinancialAssistanceApplicantBenefitType">
 		<xs:complexContent>
 			<xs:restriction base="FinancialAssistanceBenefitType">
@@ -675,7 +671,6 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="FinancialAssistanceApplicantType">
 		<xs:sequence>
 			<xs:element name="individual" type="FinancialAssistanceApplicantIndivdualType"/>
@@ -687,6 +682,10 @@
 			<xs:element name="is_claimed_as_tax_dependent" type="xs:boolean"/>
 			<xs:element name="has_insurance" type="xs:boolean"/>
 			<xs:element name="had_prior_insurance" type="xs:boolean"/>
+			<xs:element name="prior_insurance_end_on" type="SimpleDateType" minOccurs="0"/>
+			<xs:element name="is_claimed_on_other_insurance" type="xs:boolean"/>
+			<xs:element name="other_insurance_end_on" type="SimpleDateType" minOccurs="0"/>
+			<xs:element name="other_insurance_projected_amount" type="xs:integer"/>
 			<xs:element name="has_state_health_benefit" type="xs:boolean"/>
 			<xs:element name="is_medicare_eligible"/>
 			<xs:element name="is_student" type="xs:boolean"/>
@@ -722,7 +721,7 @@
 			<xs:element name="incomes">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="income" minOccurs="0" maxOccurs="unbounded" type="FinancialAssistanceIncomeEntryType"/>
+						<xs:element name="income" type="FinancialAssistanceIncomeEntryType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -753,7 +752,7 @@
 			<xs:element name="benefits">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="benefit" minOccurs="0" maxOccurs="unbounded" type="FinancialAssistanceApplicantBenefitType"/>
+						<xs:element name="benefit" type="FinancialAssistanceApplicantBenefitType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -1251,9 +1250,8 @@
 					<xs:documentation>Income, expenses and tax filing status for this Individual</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-
 			<xs:element name="verifications" type="xs:anyType" minOccurs="0"/>
-                        <xs:element name="total_incomes_by_year" type="AssistedIndividualTotalIncomesByYearType" minOccurs="0"/>
+			<xs:element name="total_incomes_by_year" type="AssistedIndividualTotalIncomesByYearType" minOccurs="0"/>
 			<xs:group ref="CommentedActiveResourceGroup"/>
 			<xs:group ref="OptionalResourceTimestampGroup"/>
 		</xs:sequence>
@@ -1321,14 +1319,25 @@
 				</xs:simpleType>
 			</xs:element>
 			<xs:element name="race" type="xs:anyURI" minOccurs="0"/>
+			<xs:element name="tribal_info" type="TribalInfoType" minOccurs="0"/>
 			<xs:element name="birth_location" type="xs:string" minOccurs="0"/>
 			<xs:element name="marital_status" type="MaritalStatusNameType" minOccurs="0"/>
 			<xs:element name="citizen_status" type="UsCitizenStatusNameType" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Individual's immigration status</xs:documentation>
+					<xs:documentation>Individual's citzenship status</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="immigration_date" type="SimpleDateType" minOccurs="0"/>
+			<xs:element name="immigration_status" type="ImmigrationStatusNameType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Individual's immigration status</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="immigration_information" type="ImmigrationInformationType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Individual's immigration information and documentation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="is_state_resident" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Person is resident of HBX state</xs:documentation>
@@ -1724,7 +1733,7 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:individual_deduction#tuition_and_fees"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:individual_deduction#ira_deduction"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:individual_deduction#student_loan_interest_deduction"/>
-                        <xs:enumeration value="urn:openhbx:terms:v1:individual_deduction#retro_deduction"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:individual_deduction#retro_deduction"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="IndividualEventNameType">
@@ -1777,7 +1786,7 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:income#title_monthly"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:income#title_yearly"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:income#strike_benefits"/>
-                        <xs:enumeration value="urn:openhbx:terms:v1:income#retro_income"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:income#retro_income"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="IndividualRequestNameType">
@@ -1833,6 +1842,7 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:preferred_contact_method#phone"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:preferred_contact_method#email"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:preferred_contact_method#post"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:preferred_contact_method#email_and_post"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="MinimumEssentialCoverageNameType">
@@ -2122,6 +2132,31 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:citizen_status#us_national"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="ImmigrationStatusNameType">
+		<xs:annotation>
+			<xs:documentation>Enumerated list of immigration status modes</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:anyURI">
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#asylee"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#refugee"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#cuban_haitian"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#amerasian_non_citizen_under_584_of_foaa"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#deportation_withheld_under_243h_or_241b_of_ina"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#special_iraqi_afghani_immigrant"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#victim_of_severe_trafficking"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#member_of_federally_recognized_indian_tribe_or_american_indian_born_in_canada"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#parolled"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#conditional_entry_granted_before_1980"/>
+			<xs:enumeration value="urn:openhbx:terms:v1:immigration_status#battered_non_citizen_spouse_child_etc"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TribalInfoType">
+		<xs:sequence>
+			<xs:element name="tribal_id" type="xs:string" minOccurs="0"/>
+			<xs:element name="tribal_name" type="xs:string" minOccurs="0"/>
+			<xs:element name="tribal_state" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:complexType name="CoverageHouseholdMembersListType">
 		<xs:sequence>
 			<xs:element name="coverage_household_member" type="PersonLinkType" minOccurs="0" maxOccurs="unbounded"/>
@@ -2181,7 +2216,7 @@
 	</xs:complexType>
 	<xs:complexType name="FamilyMembersListType">
 		<xs:sequence>
-			<xs:element name="family_member" type="ApplicantType" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element name="family_member" type="ApplicantType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:element name="renewal_consent_through_year">
@@ -2228,7 +2263,6 @@
 			<xs:element name="primary_family_member_id" type="IdentifierSimpleType"/>
 			<xs:element ref="renewal_consent_family_member_id" minOccurs="0"/>
 			<xs:element name="e_case_id" type="xs:anyURI" minOccurs="0"/>
-			<xs:element name="fin_app_id" type="xs:anyURI" minOccurs="0"/>
 			<xs:element name="households" type="HouseholdsListType" minOccurs="0"/>
 			<xs:element name="broker_accounts" type="FamilyBrokerAccountListType" minOccurs="0"/>
 			<xs:element ref="irs_groups" minOccurs="0"/>
@@ -2403,14 +2437,12 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:financial_assistance_income_wage_type#w2"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:complexType name="AssistedIndividualTotalIncomesByYearType">
 		<xs:annotation>
-	            <xs:documentation>Sum of all qualified, adjusted individual income sources, by calendar year. Also includes information about verification of the income.</xs:documentation>
+			<xs:documentation>Sum of all qualified, adjusted individual income sources, by calendar year. Also includes information about verification of the income.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-		<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
+			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 </xs:schema>

--- a/verification_services.xsd
+++ b/verification_services.xsd
@@ -4,14 +4,12 @@
 	<xs:include schemaLocation="links.xsd"/>
 	<xs:include schemaLocation="plan.xsd"/>
 	<xs:include schemaLocation="individual.xsd"/>
-
 	<xs:simpleType name="residencyVerificationResultCodeType">
 		<xs:restriction base="xs:anyURI">
 			<xs:enumeration value="urn:openhbx:terms:v1:address_verification#ADDRESS_NOT_IN_AREA"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:address_verification#ADDRESS_IN_AREA"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:complexType name="verificationQuestionResponseOptionType">
 		<xs:sequence>
 			<xs:element name="response_id" type="nonEmptyString">
@@ -19,16 +17,14 @@
 					<xs:documentation>ID of the response from RIDP - if this does not exist, use the question number.</xs:documentation>
 			    </xs:annotation>
 			</xs:element>
-                   <xs:element name="response_text" type="xs:string"/>
+			<xs:element name="response_text" type="xs:string"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="verificationQuestionResponseOptionListType">
 		<xs:sequence>
-	          <xs:element name="response_option" type="verificationQuestionResponseOptionType" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element name="response_option" type="verificationQuestionResponseOptionType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="verificationQuestionPromptType">
 		<xs:sequence>
 			<xs:element name="question_id" type="xs:string"/>
@@ -36,22 +32,19 @@
 			<xs:element name="response_options" type="verificationQuestionResponseOptionListType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="verificationQuestionResponseType">
 		<xs:sequence>
 			<xs:element name="question_id" type="xs:string"/>
-			<xs:element name="answer" type="verificationQuestionResponseOptionType" minOccurs="1"/>
-         	</xs:sequence>
+			<xs:element name="answer" type="verificationQuestionResponseOptionType"/>
+		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="verificationQuestionResponseSubmissionType">
 		<xs:sequence>
 			<xs:element name="session_id" type="xs:string"/>
 			<xs:element name="transaction_id" type="xs:string"/>
-			<xs:element name="question_response" type="verificationQuestionResponseType" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element name="question_response" type="verificationQuestionResponseType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:simpleType name="interactiveVerificationResponseCodeType">
 		<xs:restriction base="xs:anyURI">
 			<xs:enumeration value="urn:openhbx:terms:v1:interactive_identity_verification#FAILURE"/>
@@ -59,36 +52,31 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:interactive_identity_verification#MORE_INFORMATION_REQUIRED"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:simpleType name="interactiveVerificationCompleteResponseCodeType">
 		<xs:restriction base="interactiveVerificationResponseCodeType">
 			<xs:enumeration value="urn:openhbx:terms:v1:interactive_identity_verification#FAILURE"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:interactive_identity_verification#SUCCESS"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:simpleType name="interactiveVerificationSessionResponseCodeType">
 		<xs:restriction base="interactiveVerificationResponseCodeType">
 			<xs:enumeration value="urn:openhbx:terms:v1:interactive_identity_verification#MORE_INFORMATION_REQUIRED"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:complexType name="interactiveVerificationOverrideRequestType">
 		<xs:sequence>
-		   <xs:element name="transaction_id" type="xs:string"/>
+			<xs:element name="transaction_id" type="xs:string"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="interactiveVerificationResponseType">
 		<xs:sequence>
 			<xs:element name="response_code" type="interactiveVerificationResponseCodeType"/>
 			<xs:element name="response_text" type="xs:string" minOccurs="0"/>
 			<xs:element name="transaction_id" type="xs:string"/>
 			<xs:element name="session_id" type="xs:string" minOccurs="0"/>
-		        <xs:element name="question" type="verificationQuestionPromptType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="question" type="verificationQuestionPromptType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="interactiveVerificationCompletedResponseType">
 		<xs:complexContent>
 			<xs:restriction base="interactiveVerificationResponseType">
@@ -100,7 +88,6 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="verificationSessionResponseRequiredResponseType">
 		<xs:complexContent>
 			<xs:restriction base="interactiveVerificationResponseType">
@@ -108,12 +95,11 @@
 					<xs:element name="response_code" type="interactiveVerificationSessionResponseCodeType"/>
 					<xs:element name="transaction_id" type="xs:string"/>
 					<xs:element name="session_id" type="xs:string"/>
-					<xs:element name="question" type="verificationQuestionPromptType" minOccurs="1" maxOccurs="unbounded"/>
+					<xs:element name="question" type="verificationQuestionPromptType" maxOccurs="unbounded"/>
 				</xs:sequence>
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="verificationIndividualType">
 		<xs:complexContent>
 			<xs:restriction base="IndividualType">
@@ -125,38 +111,29 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="interactiveVerificationSessionStartRequestBodyType">
 		<xs:sequence>
 			<xs:element name="individual" type="verificationIndividualType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="interactiveVerificationResultBodyType">
 		<xs:choice>
 			<xs:element name="verification_result" type="interactiveVerificationCompletedResponseType"/>
 			<xs:element name="session" type="verificationSessionResponseRequiredResponseType"/>
 		</xs:choice>
 	</xs:complexType>
-
-        <xs:element name="interactive_verification_override_request" type="interactiveVerificationOverrideRequestType"/>
-        <xs:element name="interactive_verification_override_result" type="interactiveVerificationCompletedResponseType"/>
-
+	<xs:element name="interactive_verification_override_request" type="interactiveVerificationOverrideRequestType"/>
+	<xs:element name="interactive_verification_override_result" type="interactiveVerificationCompletedResponseType"/>
 	<xs:element name="interactive_verification_start" type="interactiveVerificationSessionStartRequestBodyType"/>
-
 	<xs:element name="interactive_verification_question_response" type="verificationQuestionResponseSubmissionType"/>
 	<xs:element name="interactive_verification_result" type="interactiveVerificationResultBodyType"/>
-
 	<xs:element name="residency_verification_response" type="residencyVerificationResultCodeType"/>
-
 	<xs:complexType name="residencyVerificationRequestBodyType">
 		<xs:sequence>
 			<xs:element name="individual" type="verificationIndividualType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:element name="residency_verification_request" type="residencyVerificationRequestBodyType"/>
-
 	<xs:complexType name="residencyVerificationRequestType">
 		<xs:complexContent>
 			<xs:restriction base="ServiceRequestType">
@@ -179,7 +156,6 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="residencyVerificationResponseType">
 		<xs:complexContent>
 			<xs:restriction base="ServiceResponseType">
@@ -221,7 +197,6 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="PassportInformationType">
 		<xs:sequence>
 			<xs:element name="issuing_country" type="xs:string"/>
@@ -229,36 +204,33 @@
 			<xs:element name="expiration_date" type="SimpleDateType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="ReceiptDocumentType">
 		<xs:sequence>
 			<xs:element name="receipt_number" type="xs:string"/>
 			<xs:element name="expiration_date" type="SimpleDateType"/>
 		</xs:sequence>
 	</xs:complexType>
-
-        <xs:complexType name="DocumentResultType">
+	<xs:complexType name="DocumentResultType">
 		<xs:sequence>
 			<xs:element name="case_number" type="xs:string"/>
 			<xs:element name="response_code" type="xs:string"/>
 			<xs:element name="response_description_text" type="xs:string"/>
 			<xs:element name="tds_response_description_text" type="xs:string" minOccurs="0"/>
-			<xs:element name="entry_date" minOccurs="0" type="SimpleDateType"/>
-			<xs:element name="admitted_to_date" minOccurs="0" type="SimpleDateType"/>
-			<xs:element name="admitted_to_text" minOccurs="0" type="xs:string"/>
-			<xs:element name="country_birth_code" minOccurs="0" type="xs:string"/>
-			<xs:element name="country_citizen_code" minOccurs="0" type="xs:string"/>
-			<xs:element name="coa_code" minOccurs="0" type="xs:string"/>
-			<xs:element name="eads_expire_date" minOccurs="0" type="SimpleDateType"/>
+			<xs:element name="entry_date" type="SimpleDateType" minOccurs="0"/>
+			<xs:element name="admitted_to_date" type="SimpleDateType" minOccurs="0"/>
+			<xs:element name="admitted_to_text" type="xs:string" minOccurs="0"/>
+			<xs:element name="country_birth_code" type="xs:string" minOccurs="0"/>
+			<xs:element name="country_citizen_code" type="xs:string" minOccurs="0"/>
+			<xs:element name="coa_code" type="xs:string" minOccurs="0"/>
+			<xs:element name="eads_expire_date" type="SimpleDateType" minOccurs="0"/>
 			<xs:element name="elig_statement_code" type="xs:string"/>
 			<xs:element name="elig_statement_txt" type="xs:string"/>
-			<xs:element name="iav_type_code" minOccurs="0" type="xs:string"/>
-			<xs:element name="iav_type_text" minOccurs="0" type="xs:string"/>
-			<xs:element name="grant_date" minOccurs="0" type="SimpleDateType"/>
-			<xs:element name="grant_date_reason_code" minOccurs="0" type="xs:string"/>
+			<xs:element name="iav_type_code" type="xs:string" minOccurs="0"/>
+			<xs:element name="iav_type_text" type="xs:string" minOccurs="0"/>
+			<xs:element name="grant_date" type="SimpleDateType" minOccurs="0"/>
+			<xs:element name="grant_date_reason_code" type="xs:string" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="LawfulPresenceDocumentResultsType">
 		<xs:sequence>
 			<xs:element name="document_I327" type="DocumentResultType" minOccurs="0"/>
@@ -278,7 +250,6 @@
 			<xs:element name="document_other_case_2" type="DocumentResultType" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="ImmigrationDocumentsType">
 		<xs:sequence>
 			<xs:element name="has_document_I327" type="xs:boolean"/>
@@ -298,7 +269,6 @@
 			<xs:element name="other_case_2_document_description" type="xs:string" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="ImmigrationInformationType">
 		<xs:sequence>
 			<xs:element name="also_known_as" type="xs:string" minOccurs="0"/>
@@ -311,7 +281,6 @@
 			<xs:element name="documents" type="ImmigrationDocumentsType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="LawfulPresenceRequestType">
 		<xs:sequence>
 			<xs:element name="individual" type="verificationIndividualType"/>
@@ -320,7 +289,6 @@
 			<xs:element name="requested_coverage_start_date" type="SimpleDateType"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:simpleType name="LawfulPresencePresenceCodeType">
 		<xs:restriction base="xs:anyURI">
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:presence_status#lawful_permanent_resident"/>
@@ -337,7 +305,6 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:presence_status#other"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:simpleType name="LawfulPresenceEmploymentAuthorizedCodeType">
 		<xs:restriction base="xs:anyURI">
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:employment_authorization#authorized"/>
@@ -346,21 +313,18 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:employment_authorization#cnmi_authorized_only"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:simpleType name="LawfulPresenceResponseDeterminedCodeType">
 		<xs:restriction base="xs:anyURI">
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:determination#lawfully_present"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:determination#not_lawfully_present"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:simpleType name="LawfulPresenceResponseIndeterminateCodeType">
 		<xs:restriction base="xs:anyURI">
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:determination#invalid_information"/>
 			<xs:enumeration value="urn:openhbx:terms:v1:lawful_presence:determination#additional_verification_required"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:complexType name="LawfulPresenceResponseType">
 		<xs:sequence>
 			<xs:element name="case_number" type="xs:string"/>
@@ -369,7 +333,7 @@
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="response_code" type="LawfulPresenceResponseIndeterminateCodeType"/>
-			                                <xs:element name="response_text" type="xs:string" minOccurs="0"/>
+							<xs:element name="response_text" type="xs:string" minOccurs="0"/>
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
@@ -377,7 +341,7 @@
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="response_code" type="LawfulPresenceResponseDeterminedCodeType"/>
-			                                <xs:element name="response_text" type="xs:string" minOccurs="0"/>
+							<xs:element name="response_text" type="xs:string" minOccurs="0"/>
 							<xs:element name="legal_status" type="LawfulPresencePresenceCodeType"/>
 							<xs:element name="employment_authorized" type="LawfulPresenceEmploymentAuthorizedCodeType"/>
 							<xs:element name="document_results" type="LawfulPresenceDocumentResultsType"/>
@@ -387,7 +351,6 @@
 			</xs:choice>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:simpleType name="DeathConfirmationCodeType">
 		<xs:restriction base="xs:anyURI">
 			<xs:enumeration value="urn:openhbx:terms:v1:death_confirmation#confirmed"/>
@@ -395,12 +358,11 @@
 			<xs:enumeration value="urn:openhbx:terms:v1:death_confirmation#confirmed"/>
 		</xs:restriction>
 	</xs:simpleType>
-
 	<xs:complexType name="SSAVerificationResultType">
 		<xs:sequence>
 			<xs:element name="individual" type="verificationIndividualType"/>
-		        <xs:element name="response_code" type="xs:string"/>
-		        <xs:element name="response_text" type="xs:string" minOccurs="0"/>
+			<xs:element name="response_code" type="xs:string"/>
+			<xs:element name="response_text" type="xs:string" minOccurs="0"/>
 			<xs:choice>
 				<xs:sequence>
 					<xs:element name="ssn_verification_failed" fixed="true"/>
@@ -419,46 +381,39 @@
 			</xs:choice>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:element name="ssa_verification_request" type="verificationIndividualType">
 		<xs:annotation>
 			<xs:documentation>Root element for validation requests to the SSA service.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-
 	<xs:element name="ssa_verification_result" type="SSAVerificationResultType">
 		<xs:annotation>
 			<xs:documentation>Root element for response from SSA service.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-
 	<xs:element name="lawful_presence_request" type="LawfulPresenceRequestType">
 		<xs:annotation>
 			<xs:documentation>Root element for lawful presence request.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-
 	<xs:element name="lawful_presence" type="LawfulPresenceResponseType">
 		<xs:annotation>
 			<xs:documentation>This element is the response body provided to a request for lawful presence information.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-
-        <xs:complexType name="ExternalLawfulPresenceResultType">
-           <xs:sequence>
-              <xs:element name="is_lawfully_present" type="xs:boolean"/>
-              <xs:element name="citizen_status" type="UsCitizenStatusNameType"/>
-           </xs:sequence>
-        </xs:complexType>
-
-	<xs:complexType name="VerificationSet">
+	<xs:complexType name="ExternalLawfulPresenceResultType">
 		<xs:sequence>
-                   <xs:element name="interactive_verification_results" type="xs:boolean" minOccurs="0"/>
-                   <xs:element name="lawful_presence_verification_results" type="ExternalLawfulPresenceResultType"/>
-                   <xs:element name="residency_verification_results" type="residencyVerificationResultCodeType"/>
+			<xs:element name="is_lawfully_present" type="xs:boolean"/>
+			<xs:element name="citizen_status" type="UsCitizenStatusNameType"/>
 		</xs:sequence>
 	</xs:complexType>
-
+	<xs:complexType name="VerificationSet">
+		<xs:sequence>
+			<xs:element name="interactive_verification_results" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="lawful_presence_verification_results" type="ExternalLawfulPresenceResultType"/>
+			<xs:element name="residency_verification_results" type="residencyVerificationResultCodeType"/>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:complexType name="VerifiedFamilyMemberType">
 		<xs:annotation>
 			<xs:documentation>Family member with verification results.</xs:documentation>
@@ -508,23 +463,23 @@
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
-
 	<xs:complexType name="VerifiedFamilyMembersListType">
 		<xs:sequence>
-			<xs:element name="family_member" type="VerifiedFamilyMemberType" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element name="family_member" type="VerifiedFamilyMemberType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-
 	<xs:complexType name="VerifiedFamilyType">
 		<xs:annotation>
-			<xs:documentation>Describes a family unit.</xs:documentation>                               
-		</xs:annotation>                    
-		<xs:sequence>                                                                                       
-			<xs:element name="id" type="IdentifierType"/>               
+			<xs:documentation>Describes a family unit.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="id" type="IdentifierType"/>
+			<xs:element name="fin_app_id" type="xs:anyURI" minOccurs="0"/>
+			<xs:element name="haven_app_id" type="xs:anyURI" minOccurs="0"/>
+			<xs:element name="e_case_id" type="xs:anyURI" minOccurs="0"/>
 			<xs:element name="family_members" type="VerifiedFamilyMembersListType"/>
 			<xs:group ref="FamilySharedElementsGroup"/>
 		</xs:sequence>
 	</xs:complexType>
-
-        <xs:element name="external_verified_family" type="VerifiedFamilyType"/>
+	<xs:element name="external_verified_family" type="VerifiedFamilyType"/>
 </xs:schema>


### PR DESCRIPTION
…view (EA-Haven integration)

Modifications to CV schemas for EA/HAVEN Financial Assistance
Application and Eligibility Determination integration:

financial_assistance.xsd
- Add haven_app_id to financial_assistance_application
- Add 4 new attestations the applicant must attest to to the
financial_assistance_application
o has_accepted_medicaid_insurance_collection_terms
o has_accepted_parent_living_outside_of_home_terms
o has_accepted_report_change_terms
o has_accepted_attestation_terms
-

individual.xsd
- Add prior_insurance_end_on element
- Add elements regarding claimed on other insurance
o is_claimed_on_other_insurance
o other_insurance_end_on
o other_insurance_projected_amount
- Add immigration_status on member for classification of lawful presence
attestation
- Add immigration status type enumeration for population of the
immigration_status addition above
- Add immigration_information on member for documents related to lawful
presence determination
- Add enumeration to select "email_and_post" as preferred contact method
- Add tribal_info elements and TribalInfoType to collect tribe id, tribe
name, and tribe state if Indian/Alaskan status